### PR TITLE
feat: 백엔드 v2 solver 카탈로그 연동 (qubo, raw-sa, robin)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ export default function App() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasDrawn, setHasDrawn] = useState(false);
-  const [apiTarget, setApiTarget] = useState<ApiTarget>("mr2s");
+  const [apiTarget, setApiTarget] = useState<ApiTarget>("qubo");
   const [benchmarkResult, setBenchmarkResult] =
     useState<BenchmarkResult | null>(null);
   const [benchmarkGraph, setBenchmarkGraph] = useState<ParsedGraph | null>(null);
@@ -139,9 +139,9 @@ export default function App() {
 
       const result = await runBenchmark(graph, (target, iteration) => {
         const labels: Record<string, string> = {
-          "mr2s": "MR2S",
-          "raw-sa": "Raw",
-          "brute-force": "Bruteforce",
+          "qubo": "QUBO",
+          "raw-sa": "Raw SA",
+          "robin": "Robin",
         };
         setBenchmarkProgress(`${labels[target]} ${iteration}/10...`);
       });

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,9 +8,9 @@ import type {
 import { UNREACHABLE_SCORE } from "./types.ts";
 
 const API_URLS: Record<ApiTarget, string> = {
-  "mr2s": "/api/v1/mr2s",
-  "raw-sa": "/api/v1/raw-sa",
-  "brute-force": "/api/v1/brute-force",
+  "qubo": "/api/v2/solvers/qubo",
+  "raw-sa": "/api/v2/solvers/raw-sa",
+  "robin": "/api/v2/solvers/robin",
 };
 
 export class ApiTimeoutError extends Error {
@@ -55,7 +55,7 @@ export async function optimizeSmallWorld(
 }
 
 const BENCHMARK_ITERATIONS = 10;
-const ALL_TARGETS: ApiTarget[] = ["mr2s", "raw-sa", "brute-force"];
+const ALL_TARGETS: ApiTarget[] = ["qubo", "raw-sa", "robin"];
 
 function calcWeightBalance(edges: OptimizeSmallWorldResponse["edges"]): number {
   const inW: Record<number, number> = {};

--- a/src/components/BenchmarkPanel.tsx
+++ b/src/components/BenchmarkPanel.tsx
@@ -9,9 +9,9 @@ type BenchmarkPanelProps = {
 };
 
 const APPROACH_LABELS: Record<string, string> = {
-  "mr2s": "MR2S",
-  "raw-sa": "Raw",
-  "brute-force": "Bruteforce",
+  "qubo": "QUBO",
+  "raw-sa": "Raw SA",
+  "robin": "Robin",
 };
 
 export function BenchmarkPanel({ result, loading, graph }: BenchmarkPanelProps) {

--- a/src/components/GraphInput.tsx
+++ b/src/components/GraphInput.tsx
@@ -51,17 +51,17 @@ export function GraphInput({
       <div className="field">
         <label>{t("graphInput.apiSelection")}</label>
         <div className="api-toggle">
-          <label>
+          <label title={t("graphInput.solverHint.qubo")}>
             <input
               type="radio"
               name="api-target"
-              value="mr2s"
-              checked={apiTarget === "mr2s"}
+              value="qubo"
+              checked={apiTarget === "qubo"}
               onChange={(e) => onApiTargetChange(e.target.value as ApiTarget)}
             />
-            MR2S
+            QUBO
           </label>
-          <label>
+          <label title={t("graphInput.solverHint.rawSa")}>
             <input
               type="radio"
               name="api-target"
@@ -69,17 +69,17 @@ export function GraphInput({
               checked={apiTarget === "raw-sa"}
               onChange={(e) => onApiTargetChange(e.target.value as ApiTarget)}
             />
-            Raw
+            Raw SA
           </label>
-          <label>
+          <label title={t("graphInput.solverHint.robin")}>
             <input
               type="radio"
               name="api-target"
-              value="brute-force"
-              checked={apiTarget === "brute-force"}
+              value="robin"
+              checked={apiTarget === "robin"}
               onChange={(e) => onApiTargetChange(e.target.value as ApiTarget)}
             />
-            Bruteforce
+            Robin
           </label>
         </div>
       </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -18,6 +18,11 @@
   "graphInput": {
     "title": "Graph Input",
     "apiSelection": "API Selection",
+    "solverHint": {
+      "qubo": "Partitions the graph, solves each part as a QUBO with simulated annealing",
+      "rawSa": "Anneals edge directions directly against APSP and flow metrics",
+      "robin": "One DFS pass orients every edge; fastest, but needs a bridgeless graph"
+    },
     "vertices": "Vertices (comma-separated)",
     "verticesPlaceholder": "e.g. 1,2,3,4,5",
     "edges": "Edges (one per line, space or comma-separated)",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -18,6 +18,11 @@
   "graphInput": {
     "title": "グラフ入力",
     "apiSelection": "API 選択",
+    "solverHint": {
+      "qubo": "グラフを分割し、各部分を QUBO + 焼きなましで解く",
+      "rawSa": "APSP とフロー指標を直接評価して辺の向きを焼きなます",
+      "robin": "DFS 1回で全辺の向きを確定。最速だが橋のないグラフが必要"
+    },
     "vertices": "頂点（コンマ区切り）",
     "verticesPlaceholder": "例: 1,2,3,4,5",
     "edges": "辺（1行に1つ、スペースまたはコンマ区切り）",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -18,6 +18,11 @@
   "graphInput": {
     "title": "그래프 입력",
     "apiSelection": "API 선택",
+    "solverHint": {
+      "qubo": "그래프를 분할해 각 부분을 QUBO + 시뮬레이티드 어닐링으로 계산",
+      "rawSa": "APSP와 흐름 지표를 직접 평가하며 간선 방향을 어닐링",
+      "robin": "DFS 한 번으로 전체 간선 방향 확정. 가장 빠르지만 브릿지 없는 그래프에서만 가능"
+    },
     "vertices": "정점 (쉼표로 구분)",
     "verticesPlaceholder": "예: 1,2,3,4,5",
     "edges": "간선 (한 줄에 하나씩, 띄어쓰기 또는 쉼표)",

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,8 @@ export type ParsedGraph = {
   positions?: NodePositions;
 };
 
-export type ApiTarget = "mr2s" | "raw-sa" | "brute-force";
+/** Solver names of the backend catalog: POST /api/v2/solvers/{solver}. */
+export type ApiTarget = "qubo" | "raw-sa" | "robin";
 
 /** Sentinel value returned by the API when a node is unreachable. */
 export const UNREACHABLE_SCORE = -1;


### PR DESCRIPTION
백엔드가 solver를 경로 파라미터로 받는 `/api/v2/solvers/{solver}`를 추가했다 (quantum-guardians/mr2s-backend#36). 호출 경로와 solver 목록을 교체한다.

## 변경

| solver | 변화 | 알고리즘 |
|---|---|---|
| `qubo` | 신규 (기본 선택) | 그래프 분할 후 각 부분을 QUBO+SA로 해결 |
| `raw-sa` | 유지 | 그래프 지표(APSP + flow) 기반 시뮬레이티드 어닐링 |
| `robin` | 신규 | DFS 한 번으로 전체 간선 방향 확정 (Robbins) |
| `mr2s` | 제거 | v2 카탈로그에 없음 |
| `brute-force` | 제거 | v2 카탈로그에 없음 |

- `src/api.ts`: `API_URLS`를 `/api/v2/solvers/*`로, `ALL_TARGETS`(벤치마크 대상) 교체
- `src/types.ts`: `ApiTarget` 교체
- `src/components/GraphInput.tsx`: 라디오 3개 + 각 항목 툴팁
- `src/components/BenchmarkPanel.tsx`, `src/App.tsx`: 라벨 및 기본값
- `src/i18n/locales/{en,ko,ja}.json`: `graphInput.solverHint` 3종 추가

요청/응답 body는 v1과 동일해서 어댑터 로직은 그대로다. 벤치마크도 새 3종을 10회씩 비교한다.

툴팁을 넣은 이유: "QUBO", "Robin"은 이름만으로 동작을 알기 어렵다. 이전 "Bruteforce"와 달리 설명이 필요하다.

## 검증

- `npx tsc --noEmit` — 이 PR이 건드린 파일에는 오류 없음. 남은 16개 오류는 전부 `src/components/Graph3DVisualization.tsx`의 기존 react-three-fiber JSX 타입 문제로, 이 변경과 무관하다.
- `npx vitest run` 실행 불가: `node_modules`가 root 소유라 vite temp 파일을 못 쓴다 (`EACCES .../node_modules/.vite-temp/...`). 테스트 대상(`src/utils/planar*`)은 이 PR과 무관하다.
- 브라우저 수동 확인은 배포된 백엔드에 v2가 올라간 뒤에 필요하다.

## 순서

백엔드 PR 머지·배포가 선행돼야 한다. 그 전에 배포하면 solver 호출이 404가 난다.