### PR TITLE
chore: 에이전트 지침 초기화 (AGENTS.md, .agents/docs)

### DIFF
--- a/.agents/docs/branch.md
+++ b/.agents/docs/branch.md
@@ -1,0 +1,43 @@
+# Branch Workflow
+
+## Why
+
+Predictable branch names expose intent and issue linkage without relying on local context.
+
+## Naming
+
+```text
+<type>/<issue-number>
+```
+
+Examples:
+
+```text
+feat/123
+fix/418
+docs/527
+```
+
+Allowed types:
+- `feat`: user-visible capability
+- `fix`: defect correction
+- `refactor`: behavior-preserving structure change
+- `perf`: measured performance improvement
+- `test`: test-only change
+- `docs`: documentation-only change
+- `build`: build or dependency change
+- `ci`: automation change
+- `chore`: maintenance not covered above
+
+Issue number rules:
+- digits only
+- must reference the primary issue for the branch
+- create or identify the issue before creating the branch
+
+## Lifecycle
+
+- Branch from repository default branch unless project policy says otherwise.
+- Keep one primary issue per branch.
+- Sync with default branch before final validation when divergence matters.
+- Never force-push a shared branch without coordination.
+- Delete branch after merge when no follow-up work depends on it.

--- a/.agents/docs/commit.md
+++ b/.agents/docs/commit.md
@@ -1,0 +1,47 @@
+# Commit Workflow
+
+## Why
+
+Each commit should explain one coherent change and remain safe to review or revert independently.
+
+## Format
+
+Use Conventional Commits:
+
+```text
+<type>(<optional-scope>): <한글 요약>
+```
+
+Examples:
+
+```text
+feat(auth): 세션 만료 기능 추가
+fix(api): 빈 업스트림 응답 처리
+docs: 로컬 테스트 방법 문서화
+```
+
+Use the same types defined in [`branch.md`](branch.md).
+
+## Rules
+
+- Keep subject at 50 characters or fewer when practical.
+- Write the summary after `<type>: ` in Korean. Leave code identifiers, API
+  names, CLI commands, and error strings in their original form.
+- Do not end subject with a period.
+- Describe why in body when motivation is not obvious.
+- Reference issue in footer when repository automation requires it.
+- Do not mix unrelated behavior, formatting, and refactoring.
+- Do not commit secrets, generated noise, or local-only configuration.
+
+## Body
+
+Add a body when change has non-obvious constraints or tradeoffs:
+
+```text
+fix(cache): 새로고침 중 기존 캐시 값 유지
+
+동시에 새로고침이 겹치면 읽을 수 있던 값까지 비웠다. 교체가 성공할 때까지
+이전 값을 남겨 호출부가 예측 가능한 대체 동작을 유지하게 한다.
+
+Refs #123
+```

--- a/.agents/docs/issue.md
+++ b/.agents/docs/issue.md
@@ -1,0 +1,90 @@
+# Issue Workflow
+
+## Why
+
+An issue defines the problem and acceptance boundary. It should not prescribe implementation before investigation.
+
+## Ready Criteria
+
+An issue is ready when it has:
+- clear problem statement
+- user or system impact
+- acceptance criteria
+- known constraints
+- explicit non-goals when scope could expand
+- dependencies or blockers
+
+## Issue Template
+
+```markdown
+## Problem
+
+## Impact
+
+## Acceptance Criteria
+- [ ]
+
+## Constraints
+
+## Non-goals
+
+## Validation Notes
+```
+
+## Metadata
+
+Set assignee, label, and milestone when creating the issue, not afterwards. An
+unassigned or unlabeled issue does not appear in the boards and filters the team
+uses to plan work, so it sits unseen.
+
+- **Assignee** — whoever owns the problem. Leave unset only when the issue is
+  deliberately open for pickup.
+- **Label** — at minimum the one matching the work type.
+- **Milestone or project** — when the repository tracks work that way.
+
+```bash
+gh issue create --title "<title>" --body-file /tmp/issue-body.md \
+  --assignee @me --label fix --milestone "<name>"
+```
+
+Read the repository's existing labels with `gh label list` before guessing.
+Creating a label that duplicates an existing one with different wording splits
+the boards it was meant to feed.
+
+## Language
+
+Write the title and body in Korean. Keep code identifiers, API names, CLI
+commands, and error strings in their original form.
+
+## Safe Creation
+
+Write generated issue content to a Markdown file before invoking GitHub CLI.
+Pass the file with `--body-file`; do not interpolate multiline content into
+`--body`. This prevents shell quoting, command substitution, and newline damage.
+
+Use a temporary file unless the repository requires the issue draft to be
+tracked:
+
+```bash
+gh issue create --title "<title>" --body-file /tmp/issue-body.md
+```
+
+After creation, read the remote issue back with `gh issue view` and confirm the
+title and body match the source file. Fix the remote issue before continuing if
+content is missing, truncated, or malformed. Remove temporary files after
+successful verification.
+
+## Lifecycle
+
+1. Create or refine issue.
+2. Confirm dependencies and priority.
+3. Mark in progress only when active work starts.
+4. Link branch, plan, and PR.
+5. Update scope changes in issue before implementing them.
+6. Close only after acceptance criteria and required validation pass.
+
+## Sizing
+
+Split issue when it contains multiple independently releasable outcomes or requires unrelated ownership areas.
+
+Do not split tightly coupled steps that cannot provide value or validation independently.

--- a/.agents/docs/project.md
+++ b/.agents/docs/project.md
@@ -1,0 +1,59 @@
+# Project Context
+
+Fill this document during project initialization. Agents must verify commands against repository configuration before running them.
+
+## Overview
+
+- Product: MR2S web front end — enter or generate a graph, send it to the MR2S
+  backend, and visualize the resulting edge orientation and score.
+- Repository: https://github.com/quantum-guardians/mr2s-frontend
+- Primary users: demo and benchmark audiences for the MR2S solvers.
+- Core domain: graph input, planar layout (2D / 2.5D / 3D), solver benchmarking,
+  result presentation.
+- Runtime environment: browser. Vite 7 + React 19 + TypeScript 5.9, deployed on
+  Vercel. The package is still named `qa2` in `package.json`.
+
+## Architecture
+
+- Entry points: `index.html` → `src/main.tsx` → `src/App.tsx`.
+- Main modules: `src/components/` (`GraphInput`, `GraphVisualization`,
+  `Graph3DVisualization`, `BenchmarkPanel`, `ResultPanel`, `SimulationPage`,
+  `DebugPanel`, `CircleNode`), `src/utils/` (`planarGraph`, `planarLayout`,
+  `planarLayout2_5D`, `planarLayout3D`, `validation`), `src/api.ts`,
+  `src/types.ts`, `src/i18n/` (ko, en, ja).
+- Dependency direction: components call `src/api.ts` and `src/utils/`; utils are
+  pure and framework-free, which is what makes them testable.
+- External systems: the MR2S backend at `https://quantum.yunseong.dev`. In dev
+  the Vite proxy forwards `/api`; in production the `vercel.json` rewrite does.
+- Persistent data: none. All state is in-memory.
+
+## Commands
+
+| Purpose | Command |
+|---|---|
+| Install dependencies | `npm install` |
+| Run locally | `npm run dev` |
+| Format | TODO — none configured |
+| Lint | TODO — none configured |
+| Type-check | `npx tsc --noEmit` |
+| Unit tests | `npx vitest run` — `vitest` is installed but no `test` script is defined |
+| Integration tests | TODO — none |
+| Build | `npm run build` (`tsc && vite build`) |
+
+## Constraints
+
+- Supported platforms: modern browsers; WebGL is required by the 3D and 2.5D
+  views (`three`, `@react-three/fiber`, `@react-three/drei`).
+- Compatibility requirements: the backend allows CORS only from its deployed
+  origins, so browser requests must go through the `/api` proxy or rewrite —
+  never call `https://quantum.yunseong.dev` directly from the app.
+- Performance constraints: layout and rendering cost grows with node count;
+  benchmark runs call the backend repeatedly and can be slow.
+- Security or privacy requirements: no credentials in the client.
+
+## Ownership
+
+- Maintainers: Yunseong <me@yunseong.dev>
+- Sensitive modules: `src/api.ts`, `vite.config.ts`, `vercel.json`
+- Changes requiring explicit review: backend contract changes, proxy or rewrite
+  configuration, layout algorithms in `src/utils/`.

--- a/.agents/docs/pull-request.md
+++ b/.agents/docs/pull-request.md
@@ -1,0 +1,97 @@
+# Pull Request Workflow
+
+## Why
+
+PR should let reviewer understand intent, verify evidence, and identify risk without reconstructing development history.
+
+## Before Opening
+
+- Confirm issue acceptance criteria.
+- Update plan to reflect final implementation.
+- Review full diff against default branch.
+- Remove debug code and unrelated churn.
+- Run required validation.
+- Confirm migrations, configuration, and rollback needs.
+
+## Title
+
+Use Conventional Commit format with a Korean summary:
+
+```text
+<type>(<optional-scope>): <한글 요약>
+```
+
+Write the body in Korean as well. Keep the template headings, code identifiers,
+API names, CLI commands, and error strings in their original form.
+
+## Body Template
+
+```markdown
+## Why
+
+## What Changed
+
+## Validation
+- [ ] Command or manual check
+
+## Risks
+
+## Rollback
+
+Closes #123
+```
+
+## Metadata
+
+Set assignee, label, and milestone when creating the PR, not afterwards. An
+unassigned or unlabeled PR does not appear in the boards and filters the team
+uses to find work, so it stalls without anyone noticing.
+
+- **Assignee** — whoever is responsible for landing it. Use `--assignee @me`
+  when that is you.
+- **Label** — at minimum the one matching the change type.
+- **Milestone or project** — when the repository tracks work that way.
+- **Reviewer** — request explicitly rather than relying on default rules.
+
+```bash
+gh pr create --title "<title>" --body-file /tmp/pr-body.md \
+  --assignee @me --label fix --reviewer <handle>
+```
+
+Read the repository's existing labels with `gh label list` before guessing.
+Creating a label that duplicates an existing one with different wording splits
+the boards it was meant to feed.
+
+## Safe Creation
+
+Write generated PR content to a Markdown file before invoking GitHub CLI. Pass
+the file with `--body-file`; do not interpolate multiline content into `--body`.
+This prevents shell quoting, command substitution, and newline damage.
+
+Use a temporary file unless the repository requires the PR draft to be tracked:
+
+```bash
+gh pr create --title "<title>" --body-file /tmp/pr-body.md
+```
+
+After creation, read the remote PR back with `gh pr view` and confirm the title
+and body match the source file. Fix the remote PR before reporting completion if
+content is missing, truncated, or malformed. Remove temporary files after
+successful verification.
+
+## Review Rules
+
+- Keep PR focused on one coherent outcome.
+- Mark draft while known required work remains.
+- Respond to each actionable review comment.
+- Resolve threads only after change or explicit agreement.
+- Add new commits during review when history clarity matters.
+- Squash only when repository policy prefers a single final commit.
+
+## Merge Criteria
+
+- acceptance criteria satisfied
+- required checks pass
+- review approvals complete
+- unresolved risks explicitly accepted
+- deployment or migration order documented

--- a/.agents/docs/release.md
+++ b/.agents/docs/release.md
@@ -1,0 +1,93 @@
+# Release Notes Workflow
+
+## Why
+
+Release notes are read by whoever installs or runs this version. They should
+describe what changed for that person, not how the change was produced.
+
+## Audience
+
+Write for the consumer of the build, not the reviewer of the code. Development
+narrative belongs in the pull request; planning belongs in the issue.
+
+## Body Template
+
+Write the notes in Korean. Keep code identifiers, API names, CLI commands, and
+error strings in their original form.
+
+```markdown
+한 줄 요약.
+
+## 변경
+- 사용자가 체감하는 변화
+
+## 수정
+- 고친 결함
+
+## 주의
+- 이전 버전과 달라져 미리 알아야 할 것
+
+전체 변경: #123
+```
+
+Drop any heading with no content. When fewer than about three items changed,
+keep the summary line and link the pull request instead of adding headings.
+
+## Do Not Include
+
+- **Build duration or CI progress** — untrue within minutes of publishing.
+- **Plans for the next version, or remaining work** — belongs in that version's
+  notes.
+- **Process narrative, or what was left unverified** — belongs in the pull
+  request.
+- **Internal symbol names** — translate into the observable change.
+
+## Generated Sections
+
+Release automation often appends content to the notes after builds finish:
+download tables, checksums, install instructions, hosted links. These are
+usually delimited by markers such as `<!-- links:start -->`.
+
+Treat generated blocks as owned by the automation. Do not hand-write them, and
+do not remove them.
+
+Confirm whether such automation exists before editing published notes. A job
+that appends on publish will not run again for an already-built release, so
+content removed by hand is lost until restored by hand.
+
+## Safe Editing
+
+`gh release edit --notes` and `--notes-file` both replace the entire body, not
+just the part you wrote. Editing published notes without preserving generated
+blocks silently deletes them.
+
+Write the intended body to a Markdown file and pass it with `--notes-file`; do
+not interpolate multiline content into `--notes`. This prevents shell quoting,
+command substitution, and newline damage:
+
+```bash
+gh release edit "$TAG" --notes-file /tmp/release-notes.md
+```
+
+When the release already carries a generated block, read the current body first
+and keep that block verbatim in the new file.
+
+After editing, read the remote release back with `gh release view` and confirm
+the body matches the source file, including any generated block. Fix the remote
+release before reporting completion.
+
+## Version Consistency
+
+Keep the tag and the version recorded inside the project in sync. Release
+automation usually reads only the tag, while the built artifact reports the
+in-project value, so a bump in one place does not update the other.
+
+Bump the in-project version in its own commit before tagging, and tag that
+commit.
+
+## Before Publishing
+
+- Confirm the tag points at the intended commit.
+- Confirm the in-project version matches the tag.
+- Confirm required builds succeeded when publishing gates a build.
+- Confirm notes contain no process narrative or forward-looking plans.

--- a/.agents/docs/testing.md
+++ b/.agents/docs/testing.md
@@ -1,0 +1,40 @@
+# Testing Workflow
+
+## Why
+
+Validation depth should match behavior risk and blast radius.
+
+## Strategy
+
+1. Use an installed project testing skill when one applies.
+2. Otherwise use verified commands from [`project.md`](project.md).
+3. Reproduce current failure or establish baseline.
+4. Add or update smallest test at behavior boundary.
+5. Run focused tests during implementation.
+6. Run broader suite for shared contracts or cross-module changes.
+7. Perform manual validation for user-facing behavior when automation is insufficient.
+
+## Risk-Based Coverage
+
+- Low risk: focused unit or static validation.
+- Medium risk: affected module tests plus integration boundary.
+- High risk: broad regression suite, migration or rollback check, and production-like verification.
+
+## Rules
+
+- Test observable behavior, not private implementation details.
+- Testing skill instructions override this general workflow when more specific.
+- Do not invent test commands; verify them from project configuration.
+- Keep tests deterministic and independent.
+- Avoid sleeps, network reliance, and mutable global state unless explicitly controlled.
+- Verify failure paths, boundary values, and backward compatibility when relevant.
+- Do not claim validation that was not run.
+
+## Reporting
+
+PR and handoff must state:
+- commands run
+- results
+- manual checks
+- skipped checks and reason
+- known residual risk

--- a/.agents/docs/workflow.md
+++ b/.agents/docs/workflow.md
@@ -1,0 +1,56 @@
+# Development Workflow
+
+## Why
+
+Small, explicit steps reduce regressions and make review, rollback, and handoff predictable.
+
+## Work Classification
+
+Trivial work:
+- documentation typo
+- isolated formatting fix
+- deterministic one-line configuration change
+
+Non-trivial work:
+- behavior change
+- bug fix requiring investigation
+- dependency or schema change
+- cross-module refactor
+- user-facing workflow change
+
+Non-trivial work requires a concise plan. Use the `writing-plan` skill when it
+is installed.
+
+## End-to-End Flow
+
+1. Confirm goal, scope, acceptance criteria, and non-goals.
+2. Read project context, relevant code, tests, and recent changes.
+3. Link or create an issue. Non-trivial development branches require one.
+4. Create a branch using the issue number.
+5. Write a concise implementation plan; use `writing-plan` when installed.
+6. Identify architecture impact, tradeoffs, risks, and rollback.
+7. Implement the smallest coherent change.
+8. Follow `testing.md`; use an installed testing skill when available.
+9. Review the complete diff for scope, correctness, and accidental churn.
+10. Commit coherent units using the commit convention.
+11. Open a PR with evidence and explicit remaining risk.
+12. Address review without hiding unresolved concerns.
+
+## Change Rules
+
+- Preserve existing architecture unless the task requires changing it.
+- Keep unrelated cleanup out of the change.
+- Add abstractions only when they remove demonstrated complexity or match an established pattern.
+- Keep migrations backward-compatible when practical.
+- Prefer reversible rollout for high-risk behavior.
+
+## Stop Conditions
+
+Pause and surface the problem when:
+- requirements conflict
+- destructive action lacks approval
+- required credentials or external access are unavailable
+- validation reveals an unrelated pre-existing failure that blocks confidence
+- scope expands beyond the agreed issue or plan
+
+Do not silently guess through high-impact ambiguity.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# Project Agent Instructions
+
+## Scope and Precedence
+
+This file is the repository-level entrypoint for coding agents.
+
+Read `.agents/docs/project.md` before non-trivial work. Repository-specific
+commands, constraints, and narrower instructions take precedence over these
+template defaults.
+
+## Project Workflow
+
+For non-trivial work, follow:
+
+- `.agents/docs/workflow.md`
+- `.agents/docs/testing.md`
+
+For tracked Git work, follow:
+
+- `.agents/docs/issue.md`
+- `.agents/docs/branch.md`
+- `.agents/docs/commit.md`
+- `.agents/docs/pull-request.md`
+
+For published releases, follow:
+
+- `.agents/docs/release.md`
+
+Use project-local skills when installed and applicable. Skill instructions
+define their own triggers, formats, and output paths.
+
+## Project Structure & Module Organization
+
+`index.html` boots `src/main.tsx`, which mounts `src/App.tsx`. UI lives in
+`src/components/`: `GraphInput.tsx` for edge entry, `GraphVisualization.tsx`
+and `Graph3DVisualization.tsx` for the 2D and 3D views, `BenchmarkPanel.tsx`
+for solver comparison, `ResultPanel.tsx` for scores, `SimulationPage.tsx` for
+the simulation tab. Pure logic lives in `src/utils/` — `planarGraph.ts`,
+`planarLayout.ts`, `planarLayout2_5D.ts`, `planarLayout3D.ts`, `validation.ts` —
+and is the part covered by tests. Backend calls go through `src/api.ts`, shared
+types through `src/types.ts`, and translations through `src/i18n/locales/`
+(`ko`, `en`, `ja`; Korean is the default). Keep new algorithms in `src/utils/`
+as framework-free functions rather than inside components.
+
+## Backend Integration
+
+`src/api.ts` targets the v2 solver catalog: `/api/v2/solvers/qubo`,
+`/api/v2/solvers/raw-sa`, and `/api/v2/solvers/robin`. It uses relative paths on
+purpose — the backend's CORS allowlist has no localhost entry, so requests must
+travel through the `/api` proxy in `vite.config.ts` during development and the
+`/api/(.*)` rewrite in `vercel.json` in production. Do not hardcode
+`https://quantum.yunseong.dev` into the client. `408` responses surface as
+`ApiTimeoutError`; keep that path intact, since large graphs do time out.
+
+## Build, Test, and Development Commands
+
+Install with `npm install`. Run the dev server with `npm run dev`, build with
+`npm run build` (`tsc && vite build`), and preview the build with
+`npm run preview`. There is no `test` script yet even though `vitest` is a dev
+dependency — run the suite with `npx vitest run`, and add the script when you
+next touch `package.json`. Type-check separately with `npx tsc --noEmit`.
+
+## Coding Style & Naming Conventions
+
+TypeScript with `strict`, `noUnusedLocals`, and `noUnusedParameters` enabled —
+build failures from unused bindings are intentional, so remove rather than
+suppress. Components are `PascalCase.tsx` with a default or named export
+matching the file; utilities are `camelCase.ts`. Imports of local modules carry
+the explicit `.ts` / `.tsx` extension, as `allowImportingTsExtensions` is on;
+match that. No formatter or linter is configured, so keep to the surrounding
+2-space, double-quote style. Every user-facing string goes through `i18n` with
+entries added to all three locale files.
+
+## Testing Guidelines
+
+Tests are colocated with the module under test as `<module>.test.ts` in
+`src/utils/`, run by `vitest`. Cover layout and graph logic with deterministic
+inputs — no random seeds inside assertions. When changing a layout algorithm,
+extend the matching `planarLayout*.test.ts` rather than adding a parallel file,
+and state in the pull request which views you verified visually, since the
+rendering itself is untested.
+
+## Commit & Pull Request Guidelines
+
+History uses short imperative subjects, usually with a Conventional Commit
+prefix such as `feat:` or `fix:`, occasionally in Korean. Branch names follow
+`<tag>/<issue num>`, for example `feature/2` or `feat/10`. Pull requests should
+describe the user-visible change, link the issue, note any backend contract it
+depends on, and include a screenshot when the visualization changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# CLAUDE.md
+
+MR2S web front end — a Vite + React app for entering graphs, running the MR2S
+solvers through the backend, and visualizing the resulting edge orientation.
+
+## Instructions
+
+This repository's agent instructions live in [`AGENTS.md`](AGENTS.md). Read it
+first; it links the workflow, testing, and Git documents under `.agents/docs/`.
+
+Read [`.agents/docs/project.md`](.agents/docs/project.md) before non-trivial
+work. Verify any command against repository configuration before running it —
+in particular, there is no `npm test` script yet; use `npx vitest run`.


### PR DESCRIPTION
## Why

저장소에 에이전트 지침이 없어 브랜치·커밋·테스트 규칙과 백엔드 연동 제약이 코드에만 암묵적으로 존재했다.

## What Changed

- `AGENTS.md` / `CLAUDE.md` 추가 — 저장소 진입점
- `.agents/docs/` 공용 문서 8종 설치 (workflow, testing, issue, branch, commit, pull-request, release, project)
- `.agents/docs/project.md`를 실제 구성으로 작성 (Vite 7 + React 19, `tsc && vite build`)
- 저장소 고유 규칙 기록:
  - `src/api.ts`는 상대 경로 `/api/v2/solvers/*`만 사용 — 백엔드 CORS 허용목록에 localhost가 없어 dev는 `vite.config.ts` 프록시, prod는 `vercel.json` rewrite 경유
  - `408` 응답은 `ApiTimeoutError`로 유지
  - `package.json`에 `test` 스크립트가 없으므로 `npx vitest run`
  - `tsconfig.json`의 `noUnusedLocals`/`allowImportingTsExtensions` 전제
  - 사용자 노출 문자열은 `i18n` 3개 로케일(ko/en/ja) 모두 갱신

## Validation

- [x] `AGENTS.md`가 링크한 `.agents/docs/*.md` 8개 모두 존재 확인
- [x] 기록한 명령을 `package.json`·`tsconfig.json`·`vite.config.ts`·`vercel.json`과 대조
- [x] 문서만 추가 — 소스 변경 없음

## Risks

없음. 실행 코드 변경이 없다.

## Rollback

이 커밋을 revert 하면 추가된 파일이 모두 사라진다.

Closes #15
